### PR TITLE
[SDK-292] Add Crashlytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ lint/tmp/
 *.hprof
 
 .DS_Store
+
+google-services.json

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,10 +1,11 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
+apply plugin: 'com.google.gms.google-services'
+apply plugin: 'com.google.firebase.crashlytics'
 
 def localProperties = new Properties()
 localProperties.load(new FileInputStream(rootProject.file("local.properties")))
-
 
 android {
     compileSdkVersion 30
@@ -25,6 +26,15 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+
+            firebaseCrashlytics {
+                def unstrippedLibsDir = localProperties.getProperty("dgisUnstrippedLibsDir")
+                if (unstrippedLibsDir) {
+                    nativeSymbolUploadEnabled true
+                    strippedNativeLibsDir "${project.buildDir}/intermediates/stripped_native_libs/release/out/lib"
+                    unstrippedNativeLibsDir "$unstrippedLibsDir/$dgis_sdk_version"
+                }
+            }
         }
     }
 
@@ -37,6 +47,12 @@ android {
     }
 }
 
+afterEvaluate { project ->
+    project.tasks.processDebugGoogleServices {
+       onlyIf { false }
+    }
+}
+
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
@@ -44,5 +60,10 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.android.material:material:1.1.0'
-    implementation 'ru.dgis.sdk:sdk:0.3.3'
+
+    releaseImplementation platform('com.google.firebase:firebase-bom:26.1.0')
+    releaseImplementation 'com.google.firebase:firebase-analytics'
+    releaseImplementation 'com.google.firebase:firebase-crashlytics-ndk'
+
+    implementation "ru.dgis.sdk:sdk:$dgis_sdk_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     ext {
         kotlin_version = "1.4.10"
+        dgis_sdk_version = "0.3.3"
     }
     repositories {
         google()
@@ -9,6 +10,8 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath 'com.google.gms:google-services:4.3.4'
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.4.1'
     }
 }
 


### PR DESCRIPTION
Предлагаемый способ сборки на CI:

Поместить файл с ключами гугл-сервисов google-services.json(его можно скачать в Firebase Console) в `./app`
В `local.properties` добавить
`dgisUnstrippedLibsDir=/path/to/dgisUnstrippedLibs` - путь где размещены нестрипнутые нативные библиотеки, в виде
`${dgisUnstrippedLibsDir}/${sdkVersion}/${arm64-v8a|armeabi-v7a|x86|x86_64}`
то есть, например, должен существовать файл `/path/to/dgisUnstrippedLibs/0.3.3/x86/libdgis.so`

Собрать приложение `./gradlew assembleRelease`
Выгрузить символы нативных библиотек на сервер крашлитика `./gradlew app:uploadCrashlyticsSymbolFileRelease`
