### PR TITLE
[SDK-#] Add unstripped libs for crashlytics

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.google.gms.google-services'
 apply plugin: 'com.google.firebase.crashlytics'
+apply plugin: 'de.undercouch.download'
 
 def localProperties = new Properties()
 localProperties.load(new FileInputStream(rootProject.file("local.properties")))
@@ -47,9 +48,25 @@ android {
     }
 }
 
+tasks.register('getUnstrippedLibraries', Copy) {
+    def unstrippedLibsUrl = localProperties.getProperty("dgisUnstrippedLibsUrl")
+    download {
+        src "${unstrippedLibsUrl}/libs-release-local/ru/dgis/sdk/libs/$dgis_sdk_version/libs-${dgis_sdk_version}.zip"
+        dest "$buildDir"
+        username System.getenv('ARTIFACTORY_USERNAME')
+        password System.getenv('ARTIFACTORY_PASSWORD')
+        overwrite false
+    }
+    from zipTree("$buildDir/libs-${dgis_sdk_version}.zip")
+    into "$buildDir/nativeLibs/$dgis_sdk_version"
+}
+
 afterEvaluate { project ->
     project.tasks.processDebugGoogleServices {
        onlyIf { false }
+    }
+    project.tasks.assembleRelease {
+        finalizedBy tasks.named('getUnstrippedLibraries')
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
     ext {
         kotlin_version = "1.4.10"
         dgis_sdk_version = "0.3.3"
+        gradle_download_module= "4.1.1"
     }
     repositories {
         google()
@@ -12,6 +13,7 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.4'
         classpath 'com.google.firebase:firebase-crashlytics-gradle:2.4.1'
+        classpath "de.undercouch:gradle-download-task:$gradle_download_module"
     }
 }
 


### PR DESCRIPTION
Немного изменен пайплайн: 
- Для ветки master собираем Release-вариант, для остальных - Debug (Чтобы не юзать гугловые сервисы при сборке фичеветок/develop)
- Теперь можно собирать фичеветки (Раньше - только master и develop)

Работа с unstripped libraries:
- При сборке Release-варианта (ветка master) загружаем архив с библиотеками соответствующей версии.
- Подкладываем по нужному пути с нужной структурой, и прописываем путь в local.properties
- Загружаем после билда в стадии Release deploy