### PR TITLE
[SDK-#] Choose repository in local.properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,16 +17,16 @@ buildscript {
     }
 }
 
+def localProperties = new Properties()
+localProperties.load(new FileInputStream(rootProject.file("local.properties")))
+
 allprojects {
     repositories {
         google()
         jcenter()
 
         maven {
-            def postfix = dgis_sdk_version.contains("SNAPSHOT")
-                    ? "snapshot"
-                    : "release"
-            url "http://maven.2gis.dev/libs-$postfix"
+            url localProperties.getProperty('sdkRepository', 'http://maven.2gis.dev/libs-release')
         }
     }
 }

--- a/ci/all.jenkinsfile
+++ b/ci/all.jenkinsfile
@@ -25,6 +25,7 @@ pipeline {
                     string(credentialsId: 'DGIS_DIRECTORY_APP_KEY', variable: 'DIRECTORY_KEY'),
                     string(credentialsId: 'DGIS_MAP_API_KEY', variable: 'MAP_KEY'),
                     string(credentialsId: 'NSDK_UNSTRIPPED_LIBS_BASE_URL', variable: 'UNSTRIPPED_LIBS_URL'),
+                    string(credentialsId: 'ARTIFACTORY_HOST', variable: 'ARTIFACTORY_HOST'),
                     file(credentialsId: 'NSDK_DEMOAPP_GOOGLE_SERVICES', variable: 'GOOGLE_SERVICES')
                 ]) {
                     script {
@@ -36,6 +37,10 @@ pipeline {
                         """.stripIndent()
 
                         writeFile file: "local.properties", text: localProperties
+
+                        if (env.BRANCH_NAME != 'master') {
+                            sh "echo sdkRepository=${ARTIFACTORY_HOST}/sdk-maven-all >> local.properties"
+                        }
 
                         sh "cat ${env.GOOGLE_SERVICES} > app/google-services.json"
                     }


### PR DESCRIPTION
Добавляется возможность указать пропертю `sdkRepository` в `local.properties`
Если указана - грэдл бует использовать этот репозиторий. Если нет - будет использоваться стандартный `libs-release`
На CI будем всегда использовать кастомный репозиторий, кроме сборки мастера и релиза - там sdk всегда будет браться из релизного репозитория